### PR TITLE
Update GitHub Actions to v6 for checkout and setup-buildx-action

### DIFF
--- a/.github/workflows/alert-deploy.yaml
+++ b/.github/workflows/alert-deploy.yaml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Retrieve AlertManager configuration
         with:
           repository: "statisticsnorway/nais-alert-config"
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Retrieve AlertManager configuration
         with:
           repository: "statisticsnorway/nais-alert-config"

--- a/.github/workflows/build-deploy-app.yaml
+++ b/.github/workflows/build-deploy-app.yaml
@@ -38,7 +38,7 @@ jobs:
       nais-config-path: ${{steps.nais-deploy-vars.outputs.nais_config_path}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate image tags
         id: image-tag
@@ -89,7 +89,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build and push image to NAIS Artifact Repository
         uses: nais/docker-build-push@v0

--- a/.github/workflows/build-for-ar.yaml
+++ b/.github/workflows/build-for-ar.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Authenticate to Google Cloud
       id: auth
@@ -37,7 +37,7 @@ jobs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@v6
 
     - name: Login to Artifact Registry
       uses: docker/login-action@v3

--- a/.github/workflows/nix-check.yaml
+++ b/.github/workflows/nix-check.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name:
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup python and uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary

- Updated `actions/checkout` to v6 in all workflow files.
- Updated `docker/setup-buildx-action` to v6 in `build-for-ar.yaml`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-statbank-authenticator/125)
<!-- Reviewable:end -->
