### PR TITLE
workflow: disable uv cache

### DIFF
--- a/.github/workflows/release-on-version-change.yaml
+++ b/.github/workflows/release-on-version-change.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: "3.13"
+          enable-cache: false
 
       - name: Detect version changes
         id: detect


### PR DESCRIPTION
since we only run 'uv version --short' no
build cache is created and so there is no cache to be deleted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-statbank-authenticator/170)
<!-- Reviewable:end -->
